### PR TITLE
fix: Workflow management not working when language other than English is sele...

### DIFF
--- a/resources/views/themes/default1/admin/helpdesk/manage/workflow/create.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/manage/workflow/create.blade.php
@@ -273,16 +273,16 @@ class="nav-link active"
             $('.buttons').append('<tr id="firstdata1">' +
                     '<td>' +
                     '<select class="form-control" onChange="selectdata(' + n + ')" name="action[' + n + '][a]" id="selected' + n + '" required>' +
-                    '<option value="">-- {!! Lang::get("lang.select_an_action") !!} --</option>' +
+                    '<option value="">-- {{ Lang::get('lang.select_an_action') }} --</option>' +
                     '<optgroup label="Ticket">' +
-                    '<option value="reject">{!! Lang::get("lang.reject_ticket") !!} </option>' +
-                    '<option value="department">{!! Lang::get("lang.set_department") !!} </option>' +
-                    '<option value="priority">{!! Lang::get("lang.set_priority") !!} </option>' +
-                    '<option value="sla">{!! Lang::get("lang.set_sla_plan") !!}  </option>' +
-                    '<option value="team">{!! Lang::get("lang.assign_team") !!} </option>' +
-                    '<option value="agent">{!! Lang::get("lang.assign_agent") !!} </option>' +
-                    '<option value="helptopic">{!! Lang::get("lang.set_help_topic") !!}  </option>' +
-                    '<option value="status">{!! Lang::get("lang.set_ticket_status") !!}  </option>' +
+                    '<option value="reject">{{ Lang::get('lang.reject_ticket') }} </option>' +
+                    '<option value="department">{{ Lang::get('lang.set_department') }} </option>' +
+                    '<option value="priority">{{ Lang::get('lang.set_priority') }} </option>' +
+                    '<option value="sla">{{ Lang::get('lang.set_sla_plan') }}  </option>' +
+                    '<option value="team">{{ Lang::get('lang.assign_team') }} </option>' +
+                    '<option value="agent">{{ Lang::get('lang.assign_agent') }} </option>' +
+                    '<option value="helptopic">{{ Lang::get('lang.set_help_topic') }}  </option>' +
+                    '<option value="status">{{ Lang::get('lang.set_ticket_status') }}  </option>' +
                     '</select>' +
                     '</td>' +
                     '<td id="fill' + n + '">' +
@@ -313,22 +313,22 @@ class="nav-link active"
             $('.button1').append('<tr>' +
                     '<td>' +
                     '<select class="form-control" name="rule[' + n + '][a]" required>' +
-                    '<option>-- {!! Lang::get("lang.select_one") !!} --</option>' +
-                    '<option value="email">{!! Lang::get("lang.email") !!}</option>' +
-                    '<option value="email_name">{!! Lang::get("lang.email_name") !!}</option>' +
-                    '<option value="subject">{!! Lang::get("lang.subject") !!}</option>' +
-                    '<option value="message">{!! Lang::get("lang.message") !!}/{!! Lang::get("lang.body") !!}</option>' +
+                    '<option>-- {{ Lang::get('lang.select_one') }} --</option>' +
+                    '<option value="email">{{ Lang::get('lang.email') }}</option>' +
+                    '<option value="email_name">{{ Lang::get('lang.email_name') }}</option>' +
+                    '<option value="subject">{{ Lang::get('lang.subject') }}</option>' +
+                    '<option value="message">{{ Lang::get('lang.message') }}/{{ Lang::get('lang.body') }}</option>' +
                     '</select>' +
                     '</td>' +
                     '<td>' +
                     '<select class="form-control" name="rule[' + n + '][b]" required>' +
-                    '<option value="">-- {!! Lang::get("lang.select_one") !!} --</option>' +
-                    '<option value="equal">{!! Lang::get("lang.equal_to") !!}</option>' +
-                    '<option value="not_equal">{!! Lang::get("lang.not_equal_to") !!}</option>' +
-                    '<option value="contains">{!! Lang::get("lang.contains") !!}</option>' +
-                    '<option value="dn_contain">{!! Lang::get("lang.does_not_contain") !!}</option>' +
-                    '<option value="starts">{!! Lang::get("lang.starts_with") !!}</option>' +
-                    '<option value="ends">{!! Lang::get("lang.ends_with") !!}</option>' +
+                    '<option value="">-- {{ Lang::get('lang.select_one') }} --</option>' +
+                    '<option value="equal">{{ Lang::get('lang.equal_to') }}</option>' +
+                    '<option value="not_equal">{{ Lang::get('lang.not_equal_to') }}</option>' +
+                    '<option value="contains">{{ Lang::get('lang.contains') }}</option>' +
+                    '<option value="dn_contain">{{ Lang::get('lang.does_not_contain') }}</option>' +
+                    '<option value="starts">{{ Lang::get('lang.starts_with') }}</option>' +
+                    '<option value="ends">{{ Lang::get('lang.ends_with') }}</option>' +
                     '</select>' +
                     '</td>' +
                     '<td> <input class="form-control" type="text" name="rule[' + n + '][c]" required> </td>' +

--- a/resources/views/themes/default1/admin/helpdesk/manage/workflow/edit.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/manage/workflow/edit.blade.php
@@ -282,7 +282,7 @@ class="nav-link active"
                                 <td>
                                     <select class="form-control" onChange="selectdata({!! $i !!})" id="selected{!! $i !!}" name="action[{!! $i !!}][a]" required>
                                         <option value="">-- {!! Lang::get('lang.select_an_action') !!} --</option>
-                                        <optgroup label={{trans('lang.ticket')}}>
+                                        <optgroup label="{{ trans('lang.ticket') }}">
                                             <option value="reject" <?php
                                             if ($workflow_action->condition == 'reject') {
                                                 echo "selected='selected'";
@@ -490,16 +490,16 @@ class="nav-link active"
             $('.buttons').append('<tr id="firstdata1">' +
             '<td>' +
             '<select class="form-control" onChange="selectdata(' + n + ')" name="action[' + n + '][a]" id="selected' + n + '" required>' +
-            '<option value="">-- {!! Lang::get("lang.select_an_action") !!} --</option>' +
+            '<option value="">-- {{ Lang::get('lang.select_an_action') }} --</option>' +
             '<optgroup label="Ticket">' +
-            '<option value="reject">{!! Lang::get("lang.reject_ticket") !!}</option>' +
-            '<option value="department">{!! Lang::get("lang.set_department") !!}</option>' +
-            '<option value="priority">{!! Lang::get("lang.set_priority") !!}</option>' +
-            '<option value="sla">{!! Lang::get("lang.set_sla_plan") !!}</option>' +
-            '<option value="team">{!! Lang::get("lang.assign_team") !!}</option>' +
-            '<option value="agent">{!! Lang::get("lang.assign_agent") !!} </option>' +
-            '<option value="helptopic">{!! Lang::get("lang.set_help_topic") !!} </option>' +
-            '<option value="status">{!! Lang::get("lang.set_ticket_status") !!} </option>' +
+            '<option value="reject">{{ Lang::get('lang.reject_ticket') }}</option>' +
+            '<option value="department">{{ Lang::get('lang.set_department') }}</option>' +
+            '<option value="priority">{{ Lang::get('lang.set_priority') }}</option>' +
+            '<option value="sla">{{ Lang::get('lang.set_sla_plan') }}</option>' +
+            '<option value="team">{{ Lang::get('lang.assign_team') }}</option>' +
+            '<option value="agent">{{ Lang::get('lang.assign_agent') }} </option>' +
+            '<option value="helptopic">{{ Lang::get('lang.set_help_topic') }} </option>' +
+            '<option value="status">{{ Lang::get('lang.set_ticket_status') }} </option>' +
             '</select>' +
             '</td>' +
             '<td id="fill' + n + '">' +
@@ -529,22 +529,22 @@ class="nav-link active"
             $('.button1').append('<tr>' +
             '<td>' +
             '<select class="form-control" name="rule[' + n + '][a]" required>' +
-            '<option>-- {!! Lang::get("lang.select_one") !!} --</option>' +
-            '<option value="email">{!! Lang::get("lang.email") !!}</option>' +
-            '<option value="email_name">{!! Lang::get("lang.email_name") !!}</option>' +
-            '<option value="subject">{!! Lang::get("lang.subject") !!}</option>' +
-            '<option value="message">{!! Lang::get("lang.message") !!}/{!! Lang::get("lang.body") !!}</option>' +
+            '<option>-- {{ Lang::get('lang.select_one') }} --</option>' +
+            '<option value="email">{{ Lang::get('lang.email') }}</option>' +
+            '<option value="email_name">{{ Lang::get('lang.email_name') }}</option>' +
+            '<option value="subject">{{ Lang::get('lang.subject') }}</option>' +
+            '<option value="message">{{ Lang::get('lang.message') }}/{{ Lang::get('lang.body') }}</option>' +
             '</select>' +
             '</td>' +
             '<td>' +
             '<select class="form-control" name="rule[' + n + '][b]" required>' +
-            '<option value="">-- {!! Lang::get("lang.select_one") !!} --</option>' +
-            '<option value="equal">{!! Lang::get("lang.equal_to") !!}</option>' +
-            '<option value="not_equal">{!! Lang::get("lang.not_equal_to") !!}</option>' +
-            '<option value="contains">{!! Lang::get("lang.contains") !!}</option>' +
-            '<option value="dn_contain">{!! Lang::get("lang.does_not_contain") !!}</option>' +
-            '<option value="starts">{!! Lang::get("lang.starts_with") !!}</option>' +
-            '<option value="ends">{!! Lang::get("lang.ends_with") !!}</option>' +
+            '<option value="">-- {{ Lang::get('lang.select_one') }} --</option>' +
+            '<option value="equal">{{ Lang::get('lang.equal_to') }}</option>' +
+            '<option value="not_equal">{{ Lang::get('lang.not_equal_to') }}</option>' +
+            '<option value="contains">{{ Lang::get('lang.contains') }}</option>' +
+            '<option value="dn_contain">{{ Lang::get('lang.does_not_contain') }}</option>' +
+            '<option value="starts">{{ Lang::get('lang.starts_with') }}</option>' +
+            '<option value="ends">{{ Lang::get('lang.ends_with') }}</option>' +
             '</select>' +
             '</td>' +
             '<td> <input class="form-control" type="text" name="rule[' + n + '][c]" required> </td>' +


### PR DESCRIPTION
Fixes #799

## Root cause

Unescaped translation strings injected into single-quoted JavaScript literals in workflow blade views

## Changes

- Switched the translation echoes embedded inside single-quoted JS string literals in workflow create.blade.php and edit.blade.php from raw {!! !!} to escaped {{ }} so apostrophes render as &#039; (valid JS, decoded back to ' when jQuery injects the HTML), and quoted the previously unquoted <optgroup label=...> attribute in edit.blade.php.