### PR TITLE
fix: Email config has "address" and "username" but sometimes use the address ...

### DIFF
--- a/app/Http/Controllers/Agent/helpdesk/MailController.php
+++ b/app/Http/Controllers/Agent/helpdesk/MailController.php
@@ -161,7 +161,7 @@ class MailController extends Controller
     {
         //  dd($email);
         if ($email) {
-            $username = $email->email_address;
+            $username = $email->authUsername();
             $password = $email->password;
             $service = $email->fetching_protocol;
             $host = $email->fetching_host;

--- a/app/Http/Controllers/Common/PhpMailController.php
+++ b/app/Http/Controllers/Common/PhpMailController.php
@@ -185,7 +185,7 @@ class PhpMailController extends Controller
                 $config = ['host' => $mail->sending_host,
                     'port'        => $mail->sending_port,
                     'security'    => $mail->sending_encryption,
-                    'username'    => $mail->email_address,
+                    'username'    => $mail->authUsername(),
                     'password'    => $mail->password,
                 ];
                 if (!$this->commonMailer->setSmtpDriver($config)) {

--- a/app/Model/helpdesk/Email/Emails.php
+++ b/app/Model/helpdesk/Email/Emails.php
@@ -59,6 +59,13 @@ class Emails extends BaseModel
         }
     }
 
+    public function authUsername()
+    {
+        $username = trim((string) $this->user_name);
+
+        return $username !== '' ? $username : $this->email_address;
+    }
+
     public function getPasswordAttribute($value)
     {
         try {


### PR DESCRIPTION
Fixes #696

## Root cause

SMTP/IMAP auth uses email_address instead of configured user_name

## Changes

- Added Emails::authUsername() that returns the stored user_name when present and falls back to email_address (user_name is nullable), and used it for the runtime SMTP transport config in PhpMailController::setMailConfig() and for the cron IMAP fetch in Agent MailController::fetch(), matching the existing fallback already used by EmailsController::getImapStream(). Added a unit test for the resolution logic.